### PR TITLE
Add method signatures that do not require array allocation

### DIFF
--- a/src/main/java/com/gojuno/morton/Morton64.java
+++ b/src/main/java/com/gojuno/morton/Morton64.java
@@ -92,6 +92,10 @@ public class Morton64 {
 
     public long[] unpack(long code) {
         long[] values = new long[(int)this.dimensions];
+        return unpack(code, values);
+    }
+
+    public long[] unpack(long code, long[] values) {
         for (int i = 0; i < values.length; i++) {
             values[i] = compact(code >> i);
         }
@@ -99,7 +103,12 @@ public class Morton64 {
     }
 
     public long[] sunpack(long code) {
-        long[] values = unpack(code);
+        long[] values = new long[(int)this.dimensions];
+        return sunpack(code, values);
+    }
+
+    public long[] sunpack(long code, long[] values) {
+        unpack(code, values);
         for (int i = 0; i < values.length; i++) {
             values[i] = unshiftSign(values[i]);
         }

--- a/src/test/java/com/gojuno/morton/Morton64Test.java
+++ b/src/test/java/com/gojuno/morton/Morton64Test.java
@@ -73,6 +73,11 @@ public class Morton64Test {
         long code = m.pack(values);
         long[] unpacked = m.unpack(code);
         assertArrayEquals(values, unpacked);
+
+        // Test with both the "return fresh array" and "unpack into array" signatures.
+        unpacked = new long[(int)dimensions];
+        m.unpack(code, unpacked);
+        assertArrayEquals(values, unpacked);
     }
 
     @Test
@@ -111,6 +116,11 @@ public class Morton64Test {
         Morton64 m = new Morton64(dimensions, bits);
         long code = m.spack(values);
         long[] unpacked = m.sunpack(code);
+        assertArrayEquals(values, unpacked);
+
+        // Test with both the "return fresh array" and "unpack into array" signatures.
+        unpacked = new long[(int)dimensions];
+        m.sunpack(code, unpacked);
         assertArrayEquals(values, unpacked);
     }
 


### PR DESCRIPTION
Hi, I've made a small modification that allows a user of the library to unpack a Morton code without generating garbage.